### PR TITLE
Added missing tweet fields and place, media & poll expansions

### DIFF
--- a/R/get_tweets.R
+++ b/R/get_tweets.R
@@ -29,10 +29,12 @@ get_tweets <- function(q="",n=10,start_time,end_time,token,next_token=""){
     "max_results" = n,
     "start_time" = start_time,
     "end_time" = end_time, 		
-    "tweet.fields" = "attachments,author_id,context_annotations,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,source,text,withheld",
+    "tweet.fields" = "attachments,author_id,context_annotations,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,lang,public_metrics,possibly_sensitive,referenced_tweets,source,text,withheld,reply_settings",
     "user.fields" = "created_at,description,entities,id,location,name,pinned_tweet_id,profile_image_url,protected,public_metrics,url,username,verified,withheld",
-    "expansions" = "author_id,entities.mentions.username,geo.place_id,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id",
-    "place.fields" = "contained_within,country,country_code,full_name,geo,id,name,place_type"
+    "expansions" = "author_id,entities.mentions.username,geo.place_id,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id,attachments.media_keys,attachments.poll_ids",
+    "place.fields" = "contained_within,country,country_code,full_name,geo,id,name,place_type",
+    "media.fields" = "duration_ms,height,media_key,preview_image_url,public_metrics,type,url,width",
+    "poll.fields" = "duration_minutes,end_datetime,id,options,voting_status"
   )
   if(next_token!=""){
     params[["next_token"]] <- next_token


### PR DESCRIPTION
I noticed that some tweet fields and some expansions are missing in the parameters of the call to the API. Because I think it would be useful to retrieve as much data as possible I added all missing fields to the function.

Further, I used the following code to extract the media-data:
```
# extract media data
files <- list.files(path = file.path("V2_2019/data/"), pattern = "^users_", 
                    recursive = T, include.dirs = T)
files <- paste("V2_2019/data/", files, sep = "")

df.all <- data.frame()
for (i in seq_along(files)) {
  filename = files[[i]]
  df <- jsonlite::read_json(filename, simplifyVector = TRUE)
  if(length(df) !=0 & is.data.frame(df$media)) {
    df <- df$media %>% jsonlite::flatten()
    df.all <- dplyr::bind_rows(df.all, df)
    cat("Data retrieved from file: ", filename, "\n")
  } else {
    cat("Failed to retrieve Data from file: ", filename, "\n")
  }
}
```

Code like this could potentially be included as a separate function to retrieve the expansion data. But my rudimentary code is probably not ideal for implementation.