### PR TITLE
updating test and returning error if no files are found

### DIFF
--- a/R/bind_tweet_jsons.R
+++ b/R/bind_tweet_jsons.R
@@ -21,6 +21,11 @@ bind_tweet_jsons <- function(data_path) {
       recursive = T,
       include.dirs = T
     )
+  
+  if(length(files)<1){
+    stop("There are no files matching the pattern `data_` in the specified directory.")
+  }
+  
   files <- paste(data_path, files, sep = "")
   
   pb = utils::txtProgressBar(min = 0,

--- a/tests/testthat/test-bind_tweet_jsons.R
+++ b/tests/testthat/test-bind_tweet_jsons.R
@@ -1,10 +1,25 @@
+context("bind_tweet_jsons")
+
 
 empty_dir <- tempdir()
-jsonlite::write_json(jsonlite::toJSON(mtcars), 
+
+my_cars <- mtcars
+my_cars$model <- rownames(my_cars)
+
+jsonlite::write_json(my_cars, 
                      path = file.path(empty_dir, "data_1.json"))
-jsonlite::write_json(jsonlite::toJSON(mtcars), 
+jsonlite::write_json(my_cars, 
                      path = file.path(empty_dir, "data_2.json"))
 
-test_that("Error on non-twitter json binding", {
-  expect_error(bind_tweet_jsons(empty_dir))
+test_that("Expect sucess in binding two jsons", {
+  expect_equal(bind_tweet_jsons(empty_dir),
+               dplyr::bind_rows(my_cars,my_cars))
 })
+
+unlink(empty_dir, recursive = TRUE)
+temp_dir <- tempdir()
+
+test_that("Error on finding no jsons to bind", {
+  expect_error(bind_tweet_jsons(temp_dir))
+})
+


### PR DESCRIPTION
Small addition to return an error if files are not found on the bind tweet call. Updated the testing to reflect this change as well.