### PR TITLE
fix goodpractice::gp 

### DIFF
--- a/R/add_query_prefix.R
+++ b/R/add_query_prefix.R
@@ -1,6 +1,0 @@
-add_query_prefix <- function(x, prefix){
-  q <- paste0(prefix, x)
-  q <- paste(q, collapse = " OR ")
-  q <- paste0("(",q,")")
-  return(q)
-}

--- a/R/bind_tweets.R
+++ b/R/bind_tweets.R
@@ -26,7 +26,7 @@ bind_tweets <- function(data_path, user = FALSE, verbose = TRUE) {
   }  
   json.df.all <- data.frame()
   for (i in seq_along(files)) {
-    filename = files[[i]]
+    filename <- files[[i]]
     json.df <- jsonlite::read_json(filename, simplifyVector = TRUE)
     if (user) {
       json.df <- json.df$users

--- a/R/build_queryv2.R
+++ b/R/build_queryv2.R
@@ -177,3 +177,4 @@ build_query <- function(query = NULL,
   
   return(query)
 }
+

--- a/R/get_liking_users.R
+++ b/R/get_liking_users.R
@@ -26,7 +26,7 @@ get_liking_users <- function(x, bearer_token = get_bearer(), verbose = TRUE){
   )
   
   new_df <- data.frame()
-  for(i in 1:length(x)){
+  for(i in seq_along(x)){
     cat(paste0("Processing ",x[i],"\n"))
     requrl <- paste0(url,x[i],endpoint)
     next_token <- ""

--- a/R/get_user_edges.R
+++ b/R/get_user_edges.R
@@ -71,7 +71,7 @@ get_user_edges <- function(x, bearer_token, wt, verbose = TRUE){
   }
   
   new_df <- data.frame()
-  for(i in 1:length(x)){
+  for(i in seq_along(x)){
     cat(paste0("Processing ",x[i],"\n"))
     next_token <- ""
     while (!is.null(next_token)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,7 @@ get_tweets <- function(q="",page_n=500,start_time,end_time,token,next_token="", 
   #endpoint
   url <- "https://api.twitter.com/2/tweets/search/all"
   #parameters
-  params = list(
+  params <- list(
     "query" = q,
     "max_results" = page_n,
     "start_time" = start_time,
@@ -132,12 +132,12 @@ fetch_data <- function(built_query, data_path, file, bind_tweets, start_tweets, 
     return(df.all) # return data.frame
   }
   
-  if (!is.null(data_path) & bind_tweets==T) {
+  if (!is.null(data_path) & bind_tweets) {
     return(df.all) # return data.frame
   }
   
   if (!is.null(data_path) &
-      is.null(file) & bind_tweets == F) {
+      is.null(file) & !bind_tweets) {
     .vcat(verbose, "Data stored as JSONs: use bind_tweets function to bundle into data.frame")
   }
 }
@@ -164,15 +164,15 @@ check_data_path <- function(data_path, file, bind_tweets, verbose = TRUE){
     .vwarn(verbose, "Tweets will not be stored as JSONs or as a .rds file and will only be available in local memory if assigned to an object.")
   }
   #stop clause for if user sets bind_tweets to FALSE but sets no data path
-  if (is.null(data_path) & bind_tweets == F) {
-    stop("Argument (bind_tweets = F) only valid when a data_path is specified.")
+  if (is.null(data_path) & !bind_tweets) {
+    stop("Argument (bind_tweets = FALSE) only valid when a data_path is specified.")
   }
   #warning re binding of tweets when a data path and file path have been set but bind_tweets is set to FALSE
-  if (!is.null(data_path) & !is.null(file) & bind_tweets == F) {
-    .vwarn(verbose, "Tweets will still be bound in local memory to generate .rds file. Argument (bind_tweets = F) only valid when just a data path has been specified.")
+  if (!is.null(data_path) & !is.null(file) & !bind_tweets) {
+    .vwarn(verbose, "Tweets will still be bound in local memory to generate .rds file. Argument (bind_tweets = FALSE) only valid when just a data path has been specified.")
   }
   #warning re data storage and memory limits when setting bind_tweets to TRUE 
-  if (!is.null(data_path) & is.null(file) & bind_tweets == T) {
+  if (!is.null(data_path) & is.null(file) & bind_tweets) {
     .vwarn(verbose, "Tweets will be bound in local memory as well as stored as JSONs.")
   }
 }
@@ -184,7 +184,7 @@ create_data_dir <- function(data_path, verbose = TRUE){
     invisible(data_path)
   }
   dir.create(file.path(data_path), showWarnings = FALSE)
-    invisible(data_path)  
+  invisible(data_path)  
 }
 
 df_to_json <- function(df, data_path){
@@ -234,4 +234,11 @@ create_storage_dir <- function(data_path, export_query, built_query, start_tweet
     }
   }
   return(query)
+}
+
+add_query_prefix <- function(x, prefix){
+  q <- paste0(prefix, x)
+  q <- paste(q, collapse = " OR ")
+  q <- paste0("(",q,")")
+  return(q)
 }


### PR DESCRIPTION
`goodpractice::gp` found several bad practices in the code. This patch fixes all of them, except test coverage and long lines (mostly Roxygen lines).

Actually, the usage of `importFrom` is pretty inconsistent too. But `gp` doesn't complain. So I just keep it.