### PR TITLE
Fix #338

### DIFF
--- a/R/count_all_tweets.R
+++ b/R/count_all_tweets.R
@@ -3,19 +3,9 @@
 #' This function returns aggregate counts of tweets by query string or strings
 #' between specified date ranges. 
 #'
-#' @param query string or character vector, search query or queries
-#' @param start_tweets string, starting date
-#' @param end_tweets  string, ending date
-#' @param bearer_token string, bearer token
 #' @param n integer, upper limit of tweet counts to be fetched (i.e., for 365 days n must be at least 365). Default is 100. 
-#' @param file string, name of the resulting RDS file
-#' @param data_path string, if supplied, fetched data can be saved to the designated path as jsons
-#' @param export_query If `TRUE`, queries are exported to data_path
-#' @param bind_tweets If `TRUE`, tweets captured are bound into a data.frame for assignment
-#' @param granularity string, the granularity for the search counts results. Options are "day"; "hour"; "minute". Default is day. 
-#' @param verbose If `FALSE`, query progress messages are suppressed
-#' @param ... arguments will be passed to `build_query()` function. See `?build_query()` for further information.
-#' 
+#' @param granularity string, the granularity for the search counts results. Options are "day"; "hour"; "minute". Default is day.
+#' @inheritParams get_all_tweets
 #' @return a data.frame
 #' @export
 #'
@@ -47,12 +37,6 @@ count_all_tweets <-
            granularity = "day",
            verbose = TRUE,
            ...) {    
-    if (missing(start_tweets)) {
-      stop("Start time must be specified.")
-    }
-    if (missing(end_tweets)) {
-      stop("End time must be specified.")
-    }
     
     # Build query
     built_query <- build_query(query, ...)
@@ -60,10 +44,19 @@ count_all_tweets <-
     # Building parameters for get_tweets()
     params <- list(
       "query" = built_query,
-      "start_time" = start_tweets,
-      "end_time" = end_tweets,
       "granularity" = granularity
-      )
+    )
+    if (!missing(start_tweets)) {
+      params$start_time <- start_tweets
+    }
+    if (!missing(end_tweets)) {
+      params$end_time <- end_tweets
+    }
+    if ("start_time" %in% names(params) & "end_time" %in% names(params)) {
+      ## For backward compatibility with test cases
+      params <- params[c("query", "start_time", "end_time", "granularity")]
+    }
+
     endpoint_url <- "https://api.twitter.com/2/tweets/counts/all"
     .vcat(verbose, "query: ", params[["query"]], "\n")
     

--- a/man/count_all_tweets.Rd
+++ b/man/count_all_tweets.Rd
@@ -22,9 +22,9 @@ count_all_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 
@@ -42,7 +42,7 @@ count_all_tweets(
 
 \item{verbose}{If \code{FALSE}, query progress messages are suppressed}
 
-\item{...}{arguments will be passed to \code{build_query()} function. See \code{?build_query()} for further information.}
+\item{...}{arguments will be passed to \code{\link[=build_query]{build_query()}} function. See \code{?build_query()} for further information.}
 }
 \value{
 a data.frame

--- a/man/get_all_tweets.Rd
+++ b/man/get_all_tweets.Rd
@@ -23,9 +23,9 @@ get_all_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_bbox_tweets.Rd
+++ b/man/get_bbox_tweets.Rd
@@ -24,9 +24,9 @@ get_bbox_tweets(
 
 \item{bbox}{numeric, a vector of four bounding box coordinates from west longitude to north latitude}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_country_tweets.Rd
+++ b/man/get_country_tweets.Rd
@@ -24,9 +24,9 @@ get_country_tweets(
 
 \item{country, }{string, name of country as ISO alpha-2 code e.g. "GB"}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_geo_tweets.Rd
+++ b/man/get_geo_tweets.Rd
@@ -21,9 +21,9 @@ get_geo_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_image_tweets.Rd
+++ b/man/get_image_tweets.Rd
@@ -21,9 +21,9 @@ get_image_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_lang_tweets.Rd
+++ b/man/get_lang_tweets.Rd
@@ -24,9 +24,9 @@ get_lang_tweets(
 
 \item{lang, }{string, a single BCP 47 language identifier e.g. "fr"}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_media_tweets.Rd
+++ b/man/get_media_tweets.Rd
@@ -21,9 +21,9 @@ get_media_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_mentions_tweets.Rd
+++ b/man/get_mentions_tweets.Rd
@@ -21,9 +21,9 @@ get_mentions_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_place_tweets.Rd
+++ b/man/get_place_tweets.Rd
@@ -24,9 +24,9 @@ get_place_tweets(
 
 \item{place, }{string, name of place e.g. "new york city"}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_radius_tweets.Rd
+++ b/man/get_radius_tweets.Rd
@@ -24,9 +24,9 @@ get_radius_tweets(
 
 \item{radius}{numeric, a vector of two point coordinates latitude, longitude, and point radius distance (in miles)}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_retweets_of_user.Rd
+++ b/man/get_retweets_of_user.Rd
@@ -21,9 +21,9 @@ get_retweets_of_user(
 \arguments{
 \item{users}{character vector, user handles from which to collect data}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_to_tweets.Rd
+++ b/man/get_to_tweets.Rd
@@ -21,9 +21,9 @@ get_to_tweets(
 \arguments{
 \item{users}{character vector, user handles from which to collect data}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_url_tweets.Rd
+++ b/man/get_url_tweets.Rd
@@ -21,9 +21,9 @@ get_url_tweets(
 \arguments{
 \item{query}{string, url}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_user_tweets.Rd
+++ b/man/get_user_tweets.Rd
@@ -26,9 +26,9 @@ get_user_tweets(
 \arguments{
 \item{users}{character vector, user handles from which to collect data}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/get_video_tweets.Rd
+++ b/man/get_video_tweets.Rd
@@ -21,9 +21,9 @@ get_video_tweets(
 \arguments{
 \item{query}{string or character vector, search query or queries}
 
-\item{start_tweets}{string, starting date}
+\item{start_tweets}{string, starting date; default to now - 30 days}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/man/update_collection.Rd
+++ b/man/update_collection.Rd
@@ -15,7 +15,7 @@ update_collection(
 \arguments{
 \item{data_path}{string, name of an existing data_path}
 
-\item{end_tweets}{string, ending date}
+\item{end_tweets}{string, ending date; default to now - 30 seconds}
 
 \item{bearer_token}{string, bearer token}
 

--- a/tests/testthat/test-get_all_tweets.R
+++ b/tests/testthat/test-get_all_tweets.R
@@ -4,10 +4,11 @@
 
 ## Github secret has not been set yet!
 
-test_that("defensive programming", {
-  expect_error(capture_warnings(get_all_tweets(query = "#commtwitter", end_tweets = "2021-06-05T00:00:00Z")))
-  expect_error(capture_warnings(get_all_tweets(query = "#commtwitter", start_tweets = "2021-06-05T00:00:00Z")))
-})
+
+## test_that("defensive programming", {
+##   expect_error(capture_warnings(get_all_tweets(query = "#commtwitter", end_tweets = "2021-06-05T00:00:00Z")))
+##   expect_error(capture_warnings(get_all_tweets(query = "#commtwitter", start_tweets = "2021-06-05T00:00:00Z")))
+## })
 
 
 ## require(httptest)

--- a/tests/testthat/test-real.R
+++ b/tests/testthat/test-real.R
@@ -27,4 +27,5 @@ test_that("real test", {
   ## user_ids <- unique(bind_tweets(ori_test, verbose = FALSE)$author_id)[c(6,7,9)]
   ## expect_error(get_user_profile(x = user_ids), NA)
   expect_silent(get_retweeted_by(c("1476155918597373952"), verbose = FALSE))
+  expect_error(get_all_tweets("#ichbinhanna", verbose = FALSE), NA)
 })


### PR DESCRIPTION
Allow `start_tweets` and `end_tweets` to be optional for
`get_all_tweets` and `count_all_tweets`

Also, make `count_all_tweets` inherit params from `get_all_tweets` to
reduce replications.